### PR TITLE
vfdcontrol: add plugin to formuler1 build.

### DIFF
--- a/conf/machine/formuler1.conf
+++ b/conf/machine/formuler1.conf
@@ -13,3 +13,5 @@ CHIPSET = "bcm7356"
 RCTYPE = "18"
 
 require conf/machine/include/formuler.inc
+
+OPTIONAL_BSP_ENIGMA2_PACKAGES += "enigma2-plugin-extensions-vfdcontrol"


### PR DESCRIPTION
The plugin is supplied in the BSP but never built.